### PR TITLE
Support ActiveAdmin 3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,9 @@ group :development, :test do
   gem 'sassc'
   gem 'sqlite3'
 
+  # Dummy app
+  gem 'rails'
+
   # Testing
   gem 'capybara'
   gem 'cuprite'

--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ group :development, :test do
 
   # Dummy app
   gem 'rails'
+  gem 'sprockets-rails', require: 'sprockets/railtie'
 
   # Testing
   gem 'capybara'

--- a/activeadmin_active_resource.gemspec
+++ b/activeadmin_active_resource.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.7.0'
 
-  spec.add_runtime_dependency 'activeadmin', '>= 2.0', '< 4'
+  spec.add_runtime_dependency 'activeadmin', '>= 2.0', '<= 4'
   spec.add_runtime_dependency 'activeresource', '>= 5.1'
 
   spec.add_development_dependency 'appraisal', '~> 2.4'


### PR DESCRIPTION
Relax ActiveAdmin dependency requirement to include ActiveAdmin v3, which is the first one supporting Rails 7.1.

It also includes two fixes to two errors preventing execution of `bundle exec rspec` due to missing dependencies.